### PR TITLE
replaces all versions of nodejs to 10.x 

### DIFF
--- a/cdk/cdk.out/TodoInfraStack.template.json
+++ b/cdk/cdk.out/TodoInfraStack.template.json
@@ -978,7 +978,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "Tags": [
           {
             "Key": "Name",


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #2 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
